### PR TITLE
fix: update clone command in README to include repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This project is a frontend application that allows you to generate cards with ra
 
 1. Clone this repository:
 ```bash
-git clone <repository-url>
+git clone <git@github.com:wilmarFlorez/hello-actions.git>
 cd hello-actions
 ```
 


### PR DESCRIPTION
This pull request updates the repository URL in the `README.md` file to reflect the correct repository location.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R33): Changed the placeholder `<repository-url>` in the `git clone` command to the actual repository URL `git@github.com:wilmarFlorez/hello-actions.git`.